### PR TITLE
replace metube with emacseo for originality or something

### DIFF
--- a/src/Docs/WillBoard/RTSPThread.txt
+++ b/src/Docs/WillBoard/RTSPThread.txt
@@ -1,8 +1,8 @@
-MeTube Fraud
+EmacsEo Fraud
 ------------------------------------------
 No.37814992 >>37881232
 
-I assume most people here are aware of the popular MeTuber, markkimmo.
+I assume most people here are aware of the popular EmacsEo-r, markkimmo.
 Recently a fraud has showed up under his shorter name: marky.
 He's actually getting more views than the original: something we cannot stand for.
 89.185.82.1

--- a/src/Nodes/E3/RTSP/RTSPEmailServer.xml
+++ b/src/Nodes/E3/RTSP/RTSPEmailServer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Computer id="RTSPEmail" ip="89.185.82.30" name="MeTube Email Server" type="4">
+<Computer id="RTSPEmail" ip="89.185.82.30" name="EmacsEo Email Server" type="4">
 
     <portsForCrack val="8"/>
     <ports>21,22,25,80,1433,6881,554, 443</ports>

--- a/src/Nodes/E3/RTSP/RTSPGateway1.xml
+++ b/src/Nodes/E3/RTSP/RTSPGateway1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Computer id="E3RTSPG1" ip="89.185.82.1" name="MeTube Gateway" type="4">
+<Computer id="E3RTSPG1" ip="89.185.82.1" name="EmacsEo Gateway" type="4">
     
     <portsForCrack val="2"/>
     <ports>80, 443</ports>

--- a/src/Nodes/E3/RTSP/RTSPGateway2.xml
+++ b/src/Nodes/E3/RTSP/RTSPGateway2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Computer id="E3RTSPG2" ip="89.185.82.2" name="MeTube Gateway 2" type="4">
+<Computer id="E3RTSPG2" ip="89.185.82.2" name="EmacsEo Gateway 2" type="4">
     
     <portsForCrack val="3"/>
     <ports>80, 443, 21</ports>

--- a/src/Nodes/E3/RTSP/RTSPMainServer.xml
+++ b/src/Nodes/E3/RTSP/RTSPMainServer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Computer id="RTSPMainServer" ip="89.185.82.35" name="MeTube Server" type="4">
+<Computer id="RTSPMainServer" ip="89.185.82.35" name="EmacsEo Server" type="4">
 
     <portsForCrack val="6"/>
     <ports>21, 22, 80, 443, 6881, 554</ports>

--- a/src/Nodes/E3/RTSP/RTSPPentesterWS.xml
+++ b/src/Nodes/E3/RTSP/RTSPPentesterWS.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Computer id="E3RTSPAdminWS" ip="89.185.82.200" name="MeTube Javed WS" type="1">
+<Computer id="E3RTSPAdminWS" ip="89.185.82.200" name="EmacsEo Javed WS" type="1">
     
     <portsForCrack val="5"/>
     <ports>80, 443, 21, 22, 6881</ports>
@@ -10,7 +10,7 @@
 
     <eosDevice name="Javed's phone" id="RTSPPhone" icon="ePhone2" empty="true" passOverride="notalpine">
                 
-        <mail username="javed@metube.com" pass="jJFo01l"/>
+        <mail username="javed@emacseo.com" pass="jJFo01l"/>
 
     </eosDevice>
     

--- a/src/Nodes/E3/RTSP/RTSPWS1.xml
+++ b/src/Nodes/E3/RTSP/RTSPWS1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Computer id="E3RTSPWS1" ip="89.185.82.145" name="MeTube WS1" type="1">
+<Computer id="E3RTSPWS1" ip="89.185.82.145" name="EmacsEo WS1" type="1">
     
     <portsForCrack val="3"/>
     <ports>80, 21, 22</ports>

--- a/src/Nodes/E3/RTSP/RTSPWS2.xml
+++ b/src/Nodes/E3/RTSP/RTSPWS2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Computer id="E3RTSPWS2" ip="89.185.82.146" name="MeTube WS2" type="1">
+<Computer id="E3RTSPWS2" ip="89.185.82.146" name="EmacsEo WS2" type="1">
     
     <portsForCrack val="3"/>
     <ports>80, 21, 22</ports>

--- a/src/Nodes/E3/RTSP/RTSPWS3.xml
+++ b/src/Nodes/E3/RTSP/RTSPWS3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Computer id="E3RTSPWS3" ip="89.185.82.147" name="MeTube WS3" type="1">
+<Computer id="E3RTSPWS3" ip="89.185.82.147" name="EmacsEo WS3" type="1">
     
     <portsForCrack val="3"/>
     <ports>80, 21, 22</ports>


### PR DESCRIPTION
replaced metube with emacseo, because the former (a) exists, and (b) is boring.